### PR TITLE
Added Wget read-timeout and retry

### DIFF
--- a/quickget
+++ b/quickget
@@ -846,7 +846,7 @@ function web_get() {
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
     else
-        if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+        if ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
           echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
           exit 1
         fi


### PR DESCRIPTION
Configure Wget to retry the download, when no packets are received for 10 seconds, for a total of 3 retries